### PR TITLE
Correct typo in parameter for skipping the coldet geometry check

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+build/
+external/

--- a/Arguments.cpp
+++ b/Arguments.cpp
@@ -93,7 +93,7 @@ Arguments parse_args(int argc, char **argv) {
             conf.outlier_removal = parse_outlier_removal(i->arg);
         break;
         case '\0':
-            if (i->opt->lopt == "skip_geometic_visibility_test") {
+            if (i->opt->lopt == "skip_geometric_visibility_test") {
                 conf.geometric_visibility_test = false;
             } else if (i->opt->lopt == "skip_global_seam_leveling") {
                 conf.global_seam_leveling = false;


### PR DESCRIPTION
the 2nd occurrence of the skip_geometric_visibility_test flag has a typo. thus it cannot be correctly accepted by the argument parser.
