### PR TITLE
change CMakeLists.txt such that MVE's SFM lib is not compiled (safes tim...

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -43,7 +43,7 @@ externalproject_add(mve
     GIT_REPOSITORY  https://github.com/simonfuhrmann/mve.git
     SOURCE_DIR      ${CMAKE_SOURCE_DIR}/external/mve
     CONFIGURE_COMMAND ""
-    BUILD_COMMAND   make #not platform independent
+    BUILD_COMMAND   make -C libs/mve && make -C libs/util #not platform independent
     BUILD_IN_SOURCE 1
     INSTALL_COMMAND ""
 )


### PR DESCRIPTION
...e and compile warnings)

This is as platform independent as before (read: not platform independent). 
It assumes some knowledge of the MVE lib structure but the same is true for linking against libmve and libmve_util later. No need for SFM, minimalism.