### PR TITLE
Fix mtllib paths on Windows

### DIFF
--- a/apps/texrecon/arguments.cpp
+++ b/apps/texrecon/arguments.cpp
@@ -8,6 +8,7 @@
  */
 
 #include "arguments.h"
+#include "util/file_system.h"
 
 #define SKIP_GLOBAL_SEAM_LEVELING "skip_global_seam_leveling"
 #define SKIP_GEOMETRIC_VISIBILITY_TEST "skip_geometric_visibility_test"
@@ -83,7 +84,7 @@ Arguments parse_args(int argc, char **argv) {
     Arguments conf;
     conf.in_scene = args.get_nth_nonopt(0);
     conf.in_mesh = args.get_nth_nonopt(1);
-    conf.out_prefix = args.get_nth_nonopt(2);
+    conf.out_prefix = util::fs::sanitize_path(args.get_nth_nonopt(2));
 
     /* Set defaults for optional arguments. */
     conf.data_cost_file = "";


### PR DESCRIPTION
- `out_prefix` has to be sanitized first for `util:fs::basename()` to work in
  [`ObjModel::save_to_files()`](https://github.com/nmoehrle/mvs-texturing/blob/master/libs/tex/obj_model.cpp#L32)
- This fixes the absolute path names in the resulting `.obj` and `.mtl` files
  which was reported in simonfuhrmann/mve#226.
  @igorti, can you please confirm that this fixes the bug you reported?
