### PR TITLE
Fix in-source builds on Linux

### DIFF
--- a/elibs/CMakeLists.txt
+++ b/elibs/CMakeLists.txt
@@ -32,7 +32,7 @@ externalproject_add(ext_eigen
 )
 
 externalproject_add(ext_mve
-    PREFIX          mve
+    PREFIX          ext_mve
     GIT_REPOSITORY  https://github.com/nmoehrle/mve.git
     UPDATE_COMMAND  ""
     SOURCE_DIR      ${CMAKE_SOURCE_DIR}/elibs/mve


### PR DESCRIPTION
This fixes the following error I'm getting when building in-source and MVE is
being compiled:
Error copying file "/gcc/home/andrschu/projects/mvs-test/elibs/mve/src/ext_mve-stamp/ext_mve-gitinfo.txt" to "/gcc/home/andrschu/projects/mvs-test/elibs/mve/src/ext_mve-stamp/ext_mve-gitclone-lastrun.txt".
CMake Error at mve/tmp/ext_mve-gitclone.cmake:80 (message):
  Failed to copy script-last-run stamp file:
  '/gcc/home/andrschu/projects/mvs-test/elibs/mve/src/ext_mve-stamp/ext_mve-gitclone-lastrun.txt'
