### PR TITLE
Improve delimiter detection/tokenization for MVE scenes

### DIFF
--- a/libs/tex/generate_texture_views.cpp
+++ b/libs/tex/generate_texture_views.cpp
@@ -216,8 +216,11 @@ generate_texture_views(std::string const & in_scene, std::vector<TextureView> * 
     }
 
     /* MVE_SCENE::EMBEDDING */
-    if (tok.size() == 3 && tok[1].empty()) {
-        from_mve_scene(tok[0], tok[2], texture_views);
+    size_t pos = in_scene.rfind("::");
+    if (pos != std::string::npos) {
+        std::string scene_dir = in_scene.substr(0, pos);
+        std::string image_name = in_scene.substr(pos + 2, in_scene.size());
+        from_mve_scene(scene_dir, image_name, texture_views);
     }
 
     std::size_t num_views = texture_views->size();


### PR DESCRIPTION
- ':' is allowed in paths on Linux and MacOS X
- Additionally, this allows absolute paths on Windows and fixes issue #37.