### PR TITLE
Add snap packaging

### DIFF
--- a/dist/snap/README.md
+++ b/dist/snap/README.md
@@ -1,0 +1,29 @@
+Snap is a cross-distribution packaging format for Linux. See
+https://snapcraft.io for more information.
+
+How to build
+------------
+Just type
+```
+snapcraft
+```
+from the *parent* directory: that is, not from the directory containing this
+README file, but from its parent directory. This snap has been successfully
+built in Ubuntu 16.04; more recent Ubuntu versions should work as well. Note
+that, regardless of the environment used to build it, the generated snap
+package will work on any distribution where snap is installed.
+
+How to test the snap
+--------------------
+The generated snap can be installed by typing
+```
+snap install --dangerous ./mvs-texturing*.snap
+```
+The `--dangerous` flag is needed because the snap has not been verified by the
+store.
+
+How to upload the snap to the store
+-----------------------------------
+A thorough guide can be found at the [snapcraft.io
+site](https://snapcraft.io/docs/build-snaps/publish).
+

--- a/dist/snap/snapcraft.yaml
+++ b/dist/snap/snapcraft.yaml
@@ -1,0 +1,26 @@
+name: mvs-texturing
+version: '20170215-0'
+summary: MVS Texturing - 3D Reconstruction Texturing
+description: |
+  Tool that textures 3D reconstructions from images. This project focuses on 3D
+  reconstructions generated using structure from motion and multi-view stereo
+  techniques, however, it is not limited to this setting.
+
+grade: stable
+confinement: strict
+
+apps:
+  texrecon:
+    command: texrecon
+    plugs: [home]
+
+parts:
+  mvs-texturing:
+    plugin: cmake
+    source: https://github.com/nmoehrle/mvs-texturing.git
+    source-commit: 27d6656d42d29fe225b4a1c4d4ae887416dd8b76
+    build-packages:
+      - g++
+      - libjpeg8-dev
+      - libpng12-dev
+      - libtiff5-dev


### PR DESCRIPTION
Adding snap packaging. If you want to try out the snap I generated, please run:
```
snap install mvs-texturing-mardy
```
and then the command to launch will be
```
mvs-texturing-mardy.texrecon
```
If you accept this merge proposal, please register an account for publishing the snaps, following the guide at https://snapcraft.io/docs/build-snaps/publish
Feel free to add me as a collaborator, in case you'd like me to upload snaps on your behalf.