### PR TITLE
Set materials to be 100% opaque

### DIFF
--- a/libs/tex/material_lib.cpp
+++ b/libs/tex/material_lib.cpp
@@ -32,7 +32,7 @@ MaterialLib::save_to_files(std::string const & prefix) const {
             << "Ka 1.000000 1.000000 1.000000" << std::endl
             << "Kd 1.000000 1.000000 1.000000" << std::endl
             << "Ks 0.000000 0.000000 0.000000" << std::endl
-            << "Tr 1.000000" << std::endl
+            << "Tr 0.000000" << std::endl
             << "illum 1" << std::endl
             << "Ns 1.000000" << std::endl
             << "map_Kd " << name + diffuse_map_postfix << std::endl;


### PR DESCRIPTION
Even though most software (Meshlab included) will ignore the Tr key (Transparency), currently the materials are set to be fully transparent. Some software will respect the key and happily render a fully transparent model. (Just spent a few hours figuring out why an OBJ was disappearing when I loaded its textures).

http://web.cse.ohio-state.edu/~shen.94/581/Site/Lab3_files/Labhelp_Obj_parser.htm