### PR TITLE
Added include path for the new disjoint-set datastructure in mapMAP

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -43,6 +43,7 @@ include_directories(SYSTEM
     ${CMAKE_SOURCE_DIR}/elibs/eigen
     ${CMAKE_SOURCE_DIR}/elibs/mapmap/
     ${CMAKE_SOURCE_DIR}/elibs/mapmap/mapmap
+    ${CMAKE_SOURCE_DIR}/elibs/mapmap/ext/dset
 )
 
 include_directories(


### PR DESCRIPTION
…hat gets 30% less wall-clock runtime than the old breath-first search employing vectors and spinlocks.