### PR TITLE
bugfix border condition for texturing holes

### DIFF
--- a/libs/tex/generate_texture_patches.cpp
+++ b/libs/tex/generate_texture_patches.cpp
@@ -377,8 +377,7 @@ bool fill_hole(std::vector<std::size_t> const & hole, UniGraph const & graph,
             by[idx[j]] = 0.0f;
             for (it = weights.begin(); it != weights.end(); ++it) {
                 if (is_border[it->first]) {
-                    std::size_t border_vertex_id = l2g[it->first];
-                    math::Vec2f projection = projections[g2l[border_vertex_id]];
+                    math::Vec2f projection = projections[it->first];
                     bx[idx[j]] += projection[0] * it->second;
                     by[idx[j]] += projection[1] * it->second;
                 } else {

--- a/libs/tex/generate_texture_patches.cpp
+++ b/libs/tex/generate_texture_patches.cpp
@@ -377,7 +377,7 @@ bool fill_hole(std::vector<std::size_t> const & hole, UniGraph const & graph,
             by[idx[j]] = 0.0f;
             for (it = weights.begin(); it != weights.end(); ++it) {
                 if (is_border[it->first]) {
-                    std::size_t border_vertex_id = border[idx[it->first]];
+                    std::size_t border_vertex_id = l2g[it->first];
                     math::Vec2f projection = projections[g2l[border_vertex_id]];
                     bx[idx[j]] += projection[0] * it->second;
                     by[idx[j]] += projection[1] * it->second;


### PR DESCRIPTION
The mesh parameterization for mapping texture holes is done by solving a linear equation using some barycentric weights. However the coords used to calculate b (in Ax=b) were permutated.

Explanation of issue and fix:
 * idx[] is mapping (local) indices to an _arbitrary order_ (as extracted from the faces)
 * border[] however contains the (global) indices of vertices _in the order, in which they appear on the border_.

--> border[idx[something]] is clearly messing up indices and produces wrong positions. Esp the distances to border-vertices are wrong. so the whole inner part is twisted, rotated and overlapping, even worse for bigger holes.

What you really want is mapping local to global indices, for which a nice mapping already existed. One can even resolve all the mapping.