### PR TITLE
Minor documentation clarifications

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -41,7 +41,7 @@ include_directories(SYSTEM
     ${CMAKE_SOURCE_DIR}/elibs/rayint/libs
     ${CMAKE_SOURCE_DIR}/elibs/mve/libs
     ${CMAKE_SOURCE_DIR}/elibs/eigen
-    ${CMAKE_SOURCE_DIR}/elibs/mapmap/
+    ${CMAKE_SOURCE_DIR}/elibs/mapmap
     ${CMAKE_SOURCE_DIR}/elibs/mapmap/mapmap
     ${CMAKE_SOURCE_DIR}/elibs/mapmap/ext/dset
 )

--- a/apps/texrecon/arguments.cpp
+++ b/apps/texrecon/arguments.cpp
@@ -55,7 +55,7 @@ Arguments parse_args(int argc, char **argv) {
     args.add_option('L',"labeling_file", true,
         "Skip view selection and use the labeling provided in the given file");
     args.add_option('d',"data_term", true,
-        "Data term: {" +
+        "Data term (face area, or magnitude of image gradient times face area): {" +
         choices<tex::DataTerm>() + "} [" +
         choice_string<tex::DataTerm>(tex::DATA_TERM_GMI) + "]");
     args.add_option('s',"smoothness_term", true,

--- a/libs/tex/texture_view.h
+++ b/libs/tex/texture_view.h
@@ -67,7 +67,7 @@ class TextureView {
           */
         bool valid_pixel(math::Vec2f pixel) const;
 
-        /** TODO */
+       /** Returns if all three given points (that are usually vertices of a face) project in the view at valid pixels. */
         bool inside(math::Vec3f const & v1, math::Vec3f const & v2, math::Vec3f const & v3) const;
 
         /** Returns the RGB pixel values [0, 1] for the give pixel location. */


### PR DESCRIPTION
Dear texrecon developers,

I find your tool very useful. Thank you! I use it with a flying robot that  collects depth clouds, fuses them, and textures the combined cloud with images it acquires with a separate camera. Hence the depth cloud does not come from the same modality as the textures, but your tool does great. 

Here is a tiny pull request, basically clarifying some things. As future work, I plan to expose to the user the outlier factor value and the maximum angle from a ray hitting a face and the face normal (those are now hard-coded to 6e-3 and 75 degrees), and also the maximum ray length (which now is not restricted but could be an option to avoid very far views) but that is for another time. 