### PR TITLE
Add num_threads flag to allow deterministic computation.

### DIFF
--- a/apps/texrecon/arguments.cpp
+++ b/apps/texrecon/arguments.cpp
@@ -17,6 +17,7 @@
 #define WRITE_TIMINGS "write_timings"
 #define SKIP_HOLE_FILLING "skip_hole_filling"
 #define KEEP_UNSEEN_FACES "keep_unseen_faces"
+#define NUM_THREADS "num_threads"
 
 Arguments parse_args(int argc, char **argv) {
     util::Arguments args;
@@ -86,6 +87,8 @@ Arguments parse_args(int argc, char **argv) {
         "Write out timings for each algorithm step (OUT_PREFIX + _timings.csv)");
     args.add_option('\0', NO_INTERMEDIATE_RESULTS, false,
         "Do not write out intermediate results");
+    args.add_option('\0', NUM_THREADS, true,
+        "How many threads to use. Set 1 for determinism.");
     args.parse(argc, argv);
 
     Arguments conf;
@@ -100,6 +103,8 @@ Arguments parse_args(int argc, char **argv) {
     conf.write_timings = false;
     conf.write_intermediate_results = true;
     conf.write_view_selection_model = false;
+
+    conf.num_threads = -1;
 
     /* Handle optional arguments. */
     for (util::ArgResult const* i = args.next_option();
@@ -141,6 +146,8 @@ Arguments parse_args(int argc, char **argv) {
                 conf.write_timings = true;
             } else if (i->opt->lopt == NO_INTERMEDIATE_RESULTS) {
                 conf.write_intermediate_results = false;
+            } else if (i->opt->lopt == NUM_THREADS) {
+                conf.num_threads = std::stoi(i->arg);
             } else {
                 throw std::invalid_argument("Invalid long option");
             }

--- a/apps/texrecon/arguments.h
+++ b/apps/texrecon/arguments.h
@@ -28,6 +28,8 @@ struct Arguments {
     bool write_intermediate_results;
     bool write_view_selection_model;
 
+    int num_threads;
+
     /** Returns a muliline string of the current arguments. */
     std::string to_string();
 };

--- a/apps/texrecon/texrecon.cpp
+++ b/apps/texrecon/texrecon.cpp
@@ -10,6 +10,8 @@
 #include <iostream>
 #include <fstream>
 #include <vector>
+#include <tbb/task_scheduler_init.h>
+#include <omp.h>
 
 #include <util/timer.h>
 #include <util/system.h>
@@ -55,6 +57,13 @@ int main(int argc, char **argv) {
             << "Cannot continue since this directory would be delete in the end.\n"
             << std::endl;
         std::exit(EXIT_FAILURE);
+    }
+
+    // Set the number of threads to use.
+    tbb::task_scheduler_init schedule(conf.num_threads > 0 ? conf.num_threads : tbb::task_scheduler_init::automatic);
+    if (conf.num_threads > 0) {
+        omp_set_dynamic(0);
+        omp_set_num_threads(conf.num_threads);
     }
 
     std::cout << "Load and prepare mesh: " << std::endl;


### PR DESCRIPTION
It seems like the only way to get bit-identical output is to disable multithreading. This PR adds a command-line flag to set the number of threads for both OpenMP and TBB.