### PR TITLE
Fix technically incorrect comparison in tone mapping.

### DIFF
--- a/libs/tex/generate_texture_patches.cpp
+++ b/libs/tex/generate_texture_patches.cpp
@@ -127,7 +127,7 @@ generate_candidate(int label, TextureView const & texture_view,
     byte_image = mve::image::crop(view_image, width, height, min_x, min_y, *math::Vec3uc(255, 0, 255));
     mve::FloatImage::Ptr image = mve::image::byte_to_float_image(byte_image);
 
-    if (!settings.tone_mapping == TONE_MAPPING_NONE) {
+    if (settings.tone_mapping == TONE_MAPPING_GAMMA) {
         mve::image::gamma_correct(image, 2.2f);
     }
 


### PR DESCRIPTION
Fix for https://github.com/nmoehrle/mvs-texturing/commit/181b33661d813be4daba7802184ee0ce51947daa#r37229123:

Clang 7 warnings show:

    libs/tex/generate_texture_patches.cpp:130:9: warning: logical not is only applied to the left hand side of this comparison [-Wlogical-not-parentheses]
        if (!settings.tone_mapping == TONE_MAPPING_NONE) {
            ^                      ~~
    libs/tex/generate_texture_patches.cpp:130:9: note: add parentheses after the '!' to evaluate the comparison first
        if (!settings.tone_mapping == TONE_MAPPING_NONE) {
            ^
             (                                         )
    libs/tex/generate_texture_patches.cpp:130:9: note: add parentheses around left hand side expression to silence this warning
        if (!settings.tone_mapping == TONE_MAPPING_NONE) {
            ^
            (                     )

`!` binds tigther than `==`, so what was there so far was
`if ((!settings.tone_mapping) == TONE_MAPPING_NONE) {`
which is semantically incorrect.

It is still bug-free currently because only values `0` and `1` in enum

    enum ToneMapping {
        TONE_MAPPING_NONE = 0,
        TONE_MAPPING_GAMMA = 1
    };

but as soon as add a third value will be added, this would be wrong.

This commit fixes it by directly checking `TONE_MAPPING_GAMMA` for applying
the `gamma_correct()` function.