### PR TITLE
Fix compile error. The VERSION constant is conflicting with ROS

### DIFF
--- a/libs/tex/sparse_table.h
+++ b/libs/tex/sparse_table.h
@@ -21,7 +21,7 @@
 #include "util/exception.h"
 
 #define HEADER "SPT"
-#define VERSION "0.2"
+#define TEX_SPARSE_TABLE_VERSION "0.2"
 
 /**
   * Class representing a sparse table optimized for row and column wise access.
@@ -118,7 +118,7 @@ SparseTable<C, R, T>::save_to_file(SparseTable const & sparse_table, const std::
     C cols = sparse_table.cols();
     R rows = sparse_table.rows();
     std::size_t nnz = sparse_table.get_nnz();
-    out << HEADER << " " << VERSION << " " << cols << " " << rows << " " << nnz << std::endl;
+    out << HEADER << " " << TEX_SPARSE_TABLE_VERSION << " " << cols << " " << rows << " " << nnz << std::endl;
 
     for (C col = 0; col < cols; ++col) {
         SparseTable::Column column = sparse_table.col(col);
@@ -153,7 +153,7 @@ SparseTable<C, R, T>::load_from_file(const std::string & filename, SparseTable<C
     std::string version;
     in >> version;
 
-    if (version != VERSION) {
+    if (version != TEX_SPARSE_TABLE_VERSION) {
         in.close();
         throw util::FileException(filename, "Incompatible version of SparseTable file!");
     }


### PR DESCRIPTION
The macro VERSION is something too general. In my case it conflicts with a VERSION variable in a ROS package. Ideally this should not even be a macro, rather a C++ constant variable within the local namespace. 