### PR TITLE
Changing unavailable eigen source

### DIFF
--- a/elibs/CMakeLists.txt
+++ b/elibs/CMakeLists.txt
@@ -22,8 +22,8 @@ externalproject_add(ext_rayint
 
 externalproject_add(ext_eigen
     PREFIX          ext_eigen
-    URL             https://bitbucket.org/eigen/eigen/get/3.3.2.tar.gz
-    URL_MD5         36b5731ab7d7e0c10843ac93bd9fd270
+    URL             https://gitlab.com/libeigen/eigen/-/archive/3.3.2/eigen-3.3.2.tar.gz
+    URL_MD5         02edfeec591ae09848223d622700a10b
     SOURCE_DIR      ${CMAKE_SOURCE_DIR}/elibs/eigen
     CONFIGURE_COMMAND ""
     BUILD_COMMAND   ""


### PR DESCRIPTION
The link https://bitbucket.org/eigen/eigen/get/3.3.2.tar.gz does not work anymore.
I changed it to the one in the official eigen website http://eigen.tuxfamily.org/index.php?title=Main_Page pointing to https://gitlab.com/libeigen/eigen/-/releases