### PR TITLE
Updated git tag for mapmap

### DIFF
--- a/elibs/CMakeLists.txt
+++ b/elibs/CMakeLists.txt
@@ -1,7 +1,7 @@
 externalproject_add(ext_mapmap
     PREFIX          ext_mapmap
     GIT_REPOSITORY  https://github.com/dthuerck/mapmap_cpu.git
-    GIT_TAG         master
+    GIT_TAG         55d14fd
     UPDATE_COMMAND  ""
     SOURCE_DIR      ${CMAKE_SOURCE_DIR}/elibs/mapmap
     CONFIGURE_COMMAND ""


### PR DESCRIPTION
Recent change in `mapmap` repository causes the texrecon not to be build. Hence updating the git tag for `mapmap` to last commit.